### PR TITLE
nodebrewのuse実行とパスを通すコマンドを追加

### DIFF
--- a/dev/target/install-node.sh
+++ b/dev/target/install-node.sh
@@ -6,3 +6,7 @@ cd $(dirname $0)
 brew install nodebrew
 mkdir -p ~/.nodebrew/src
 nodebrew install-binary latest
+nodebrew use latest
+
+# パスを通す
+echo '\n# nodebrew\nexport PATH=$HOME/.nodebrew/current/bin:$PATH' >> ~/.zshrc


### PR DESCRIPTION
### 概要
nodebrewのuse実行とパスを通すコマンドを追加した

### 詳細
`echo '\n# nodebrew\nexport PATH=$HOME/.nodebrew/current/bin:$PATH' >> ~/.zshrc`で.zshrcに下記が追記される

```
# nodebrew
export PATH=$HOME/.nodebrew/current/bin:$PATH
```